### PR TITLE
Feature/auto reset fan throttle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,6 +359,7 @@ dependencies = [
  "crossbeam-channel",
  "ctrlc",
  "env_logger",
+ "int-enum",
  "log",
  "sysinfo",
  "windres",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1145cf131a2c6ba0615079ab6a638f7e1973ac9c2634fcbeaaad6114246efe8c"
+dependencies = [
+ "autocfg",
+ "cfg-if 1.0.0",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +308,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "env_logger"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +360,7 @@ dependencies = [
  "ctrlc",
  "env_logger",
  "log",
+ "sysinfo",
  "windres",
 ]
 
@@ -591,6 +623,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "num-derive"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -608,6 +649,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -653,6 +704,12 @@ checksum = "3370abb7372ed744232c12954d920d1a40f1c4686de9e79e800021ef492294bd"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "parking_lot"
@@ -726,6 +783,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
 ]
 
 [[package]]
@@ -850,6 +931,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.23.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf915673a340ee41f2fc24ad1286c75ea92026f04b65a0d0e5132d80b95fc61"
+dependencies = [
+ "cfg-if 1.0.0",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ crossbeam-channel = "~0.5.4"
 ctrlc = "~3.2.2"
 env_logger = "~0.9.0"
 log = "~0.4.17"
+sysinfo = "~0.23.11"
 
 [build-dependencies]
 windres = "~0.2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ cpal = "~0.13.5"
 crossbeam-channel = "~0.5.4"
 ctrlc = "~3.2.2"
 env_logger = "~0.9.0"
+int-enum = "~0.4.0"
 log = "~0.4.17"
 sysinfo = "~0.23.11"
 

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -1,11 +1,17 @@
 use ati_adl_sys::{
     Adl, AdlAdapterInfo, AdlSensorType, AdlStatus, ADL_CONTEXT_HANDLE, ATI_VENDOR_ID,
 };
+use int_enum::IntEnum;
+use sysinfo::{ProcessExt, System, SystemExt};
+
+use std::fs;
+use std::process::Command;
 
 pub struct Gpu {
     adl: Adl,
     context: ADL_CONTEXT_HANDLE,
     active_adapters: Vec<AdlAdapterInfo>,
+    system: System,
 }
 
 impl Gpu {
@@ -40,6 +46,7 @@ impl Gpu {
                 adl,
                 context,
                 active_adapters,
+                system: System::new_all(),
             }
         } else {
             panic!("Unable to find any active GPUs")
@@ -104,6 +111,71 @@ impl Gpu {
             })
             .collect()
     }
+
+    fn kill_asrock_tweak_tool(&mut self) {
+        self.system.refresh_processes();
+        for (pid, proc) in self
+            .system
+            .processes()
+            .iter()
+            .filter(|(_pid, proc)| !proc.cmd().is_empty() && proc.cmd()[0].contains("AsrPGT"))
+        {
+            info!("Killing ASRock Tweak Tool (process {})", pid);
+            if !proc.kill() {
+                warn!("Unable to kill process!");
+            }
+        }
+    }
+
+    fn set_fan_throttle(&self, fan_throttle: FanThrottle) {
+        let file_name = "C:\\Program Files (x86)\\ASRock Utility\\ASRPGT\\Bin\\AsrPGT.ini";
+
+        let curr_file_contents = fs::read_to_string(file_name)
+            .unwrap_or_else(|_| panic!("Unable to read config file {}", file_name));
+        let new_file_contents = curr_file_contents
+            .split('\n')
+            .into_iter()
+            .map(|line| {
+                if line.starts_with("FanMode") {
+                    format!("FanMode={}", fan_throttle.int_value())
+                } else {
+                    line.to_string()
+                }
+            })
+            .collect::<Vec<String>>()
+            .join("\n");
+
+        fs::write(file_name, new_file_contents)
+            .unwrap_or_else(|_| panic!("Unable to write config file {}", file_name));
+    }
+
+    fn launch_asrock_tweak_tool(&self) {
+        Command::new("C:\\Program Files (x86)\\ASRock Utility\\ASRPGT\\Bin\\AsrPGT.exe")
+            .spawn()
+            .expect("Unable to launch ASRock Tweak Tool");
+
+        // allow time for process to complete launching before continuing
+        std::thread::sleep(std::time::Duration::from_millis(2000));
+    }
+
+    pub fn reset_fan_throttle(&mut self) {
+        self.kill_asrock_tweak_tool();
+        info!("Changing to fixed fan throttle");
+        self.set_fan_throttle(FanThrottle::Fixed);
+        self.launch_asrock_tweak_tool();
+        self.kill_asrock_tweak_tool();
+        info!("Changing back to smart fan throttle");
+        self.set_fan_throttle(FanThrottle::Smart);
+        self.launch_asrock_tweak_tool();
+    }
+}
+
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, IntEnum)]
+enum FanThrottle {
+    Smart = 0,
+    Fixed = 1,
+    Customize = 2,
 }
 
 impl Drop for Gpu {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ extern crate ctrlc;
 extern crate env_logger;
 #[macro_use]
 extern crate log;
+extern crate sysinfo;
 
 mod gpu;
 mod sound;

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,8 @@ extern crate crossbeam_channel;
 extern crate ctrlc;
 extern crate env_logger;
 #[macro_use]
+extern crate int_enum;
+#[macro_use]
 extern crate log;
 extern crate sysinfo;
 
@@ -22,7 +24,7 @@ fn main() -> anyhow::Result<()> {
     let env = Env::default().filter_or("MY_LOG_LEVEL", "info");
     env_logger::init_from_env(env);
 
-    let gpu = Gpu::get_active_gpu();
+    let mut gpu = Gpu::get_active_gpu();
 
     fn ctrl_channel() -> Result<Receiver<()>, ctrlc::Error> {
         let (sender, receiver) = bounded(100);
@@ -36,11 +38,11 @@ fn main() -> anyhow::Result<()> {
     let ctrl_c_events = ctrl_channel()?;
     let ticks = tick(Duration::from_secs(2));
 
-    check_temps(&gpu)?;
+    check_temps(&mut gpu)?;
     loop {
         select! {
             recv(ticks) -> _ => {
-                check_temps(&gpu)?;
+                check_temps(&mut gpu)?;
             }
             recv(ctrl_c_events) -> _ => {
                 info!("Exiting!");
@@ -52,7 +54,7 @@ fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-fn check_temps(gpu: &Gpu) -> anyhow::Result<()> {
+fn check_temps(gpu: &mut Gpu) -> anyhow::Result<()> {
     for (adapter, result) in gpu.get_temps() {
         match result {
             Ok(temps) => {
@@ -62,6 +64,7 @@ fn check_temps(gpu: &Gpu) -> anyhow::Result<()> {
                 );
 
                 if temps.fan_speed_rpm == 65535 {
+                    gpu.reset_fan_throttle();
                     sound::alert()?;
                 }
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,17 @@ fn check_temps(gpu: &mut Gpu) -> anyhow::Result<()> {
 
                 if temps.fan_speed_rpm == 65535 {
                     gpu.reset_fan_throttle();
+                }
+            }
+            Err(s) => eprintln!("Unable to get sensors for adapter {:?}: {:?}", adapter, s),
+        }
+    }
+
+    // if any adapters still have an invalid speed, then alert audibly
+    for (adapter, result) in gpu.get_temps() {
+        match result {
+            Ok(temps) => {
+                if temps.fan_speed_rpm == 65535 {
                     sound::alert()?;
                 }
             }


### PR DESCRIPTION
Allow the program to fix the fan throttle issue instead of just alerting about it audibly.  The reset is done in a super janky way, but at least it works.  The basic flow revolves around editing the config file for ASRock Tweak Tool and restarting the tweak tool so it reads in the new value from disk.