### PR TITLE
Replacing log/env_logger with tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "alsa"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,6 +25,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,17 +48,6 @@ dependencies = [
  "libloading",
  "strum",
  "strum_macros",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -308,19 +297,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
 
 [[package]]
-name = "env_logger"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2cf0344971ee6c64c31be0d530793fba457d322dfec2810c453d0ef228f9c3"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,10 +317,11 @@ dependencies = [
  "cpal",
  "crossbeam-channel",
  "ctrlc",
- "env_logger",
  "int-enum",
- "log",
  "sysinfo",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
  "winres",
 ]
 
@@ -362,12 +339,6 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "ident_case"
@@ -406,6 +377,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "jni"
@@ -674,6 +651,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "oboe"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,6 +718,12 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "pkg-config"
@@ -816,8 +808,6 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
- "aho-corasick",
- "memchr",
  "regex-syntax",
 ]
 
@@ -859,6 +849,15 @@ name = "serde"
 version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
 
 [[package]]
 name = "shlex"
@@ -930,15 +929,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -959,6 +949,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "time"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db76ff9fa4b1458b3c7f077f3ff9887394058460d21e634355b273aaf11eea45"
+dependencies = [
+ "itoa",
+ "libc",
+ "num_threads",
+]
+
+[[package]]
 name = "toml"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,10 +978,85 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
+dependencies = [
+ "cfg-if 1.0.0",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
+dependencies = [
+ "crossbeam-channel",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
+dependencies = [
+ "ansi_term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,11 @@ anyhow = "~1.0.62"
 cpal = "~0.13.5"
 crossbeam-channel = "~0.5.6"
 ctrlc = "~3.2.3"
-env_logger = "~0.9.0"
 int-enum = "~0.4.0"
-log = "~0.4.17"
 sysinfo = "~0.25.1"
+tracing = "~0.1.36"
+tracing-appender = "~0.2.2"
+tracing-subscriber = "~0.3.15"
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "~0.1.12"

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -3,6 +3,7 @@ use ati_adl_sys::{
 };
 use int_enum::IntEnum;
 use sysinfo::{ProcessExt, System, SystemExt};
+use tracing::{info, warn};
 
 use std::fs;
 use std::process::Command;

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -3,7 +3,7 @@ use ati_adl_sys::{
 };
 use int_enum::IntEnum;
 use sysinfo::{ProcessExt, System, SystemExt};
-use tracing::{info, warn};
+use tracing::{info, info_span, warn};
 
 use std::fs;
 use std::process::Command;
@@ -17,6 +17,9 @@ pub struct Gpu {
 
 impl Gpu {
     pub fn get_active_gpu() -> Self {
+        let span = info_span!("Getting active GPU");
+        let _guard = span.enter();
+
         let adl = Adl::default();
 
         adl.ADL_Main_Control_Create(1)
@@ -30,11 +33,15 @@ impl Gpu {
             Ok((_, num)) => num,
             Err(s) => panic!("Unable to get number of adapters: {:?}", s),
         };
-        info!("Found {} adapters", num_adapters);
+        info!(num_adapters, "Found {} adapters", num_adapters);
 
         if num_adapters > 0 {
             let active_adapters = Self::get_active_adapters(&adl);
             info!(
+                ati_amd_adapters = ?active_adapters
+                    .iter()
+                    .map(|a| a.adapter_name.clone())
+                    .collect::<Vec<String>>(),
                 "Found {:?} active adapters from ATI/AMD: {:?}",
                 active_adapters.len(),
                 active_adapters
@@ -114,6 +121,9 @@ impl Gpu {
     }
 
     pub fn ensure_asrock_tweak_tool_running(&mut self) {
+        let span = info_span!("Ensure ASRock Tweak Tool running");
+        let _guard = span.enter();
+
         self.system.refresh_processes();
         if self
             .system
@@ -133,6 +143,9 @@ impl Gpu {
     }
 
     fn kill_asrock_tweak_tool(&mut self) {
+        let span = info_span!("Killing ASRock Tweak Tool");
+        let _guard = span.enter();
+
         self.system.refresh_processes();
         for (pid, proc) in self
             .system
@@ -140,7 +153,7 @@ impl Gpu {
             .iter()
             .filter(|(_pid, proc)| !proc.cmd().is_empty() && proc.cmd()[0].contains("AsrPGT"))
         {
-            info!("Killing ASRock Tweak Tool (process {})", pid);
+            info!(?pid, "Killing ASRock Tweak Tool (process {})", pid);
             if !proc.kill() {
                 warn!("Unable to kill process!");
             }
@@ -148,6 +161,10 @@ impl Gpu {
     }
 
     fn set_fan_throttle(&self, fan_throttle: FanThrottle) {
+        let span = info_span!("Setting fan throttle");
+        let _guard = span.enter();
+        info!(?fan_throttle, "Setting fan throttle: {:?}", fan_throttle);
+
         let file_name = "C:\\Program Files (x86)\\ASRock Utility\\ASRPGT\\Bin\\AsrPGT.ini";
 
         let curr_file_contents = fs::read_to_string(file_name)
@@ -170,6 +187,9 @@ impl Gpu {
     }
 
     fn launch_asrock_tweak_tool(&self) {
+        let span = info_span!("Launching ASRock Tweak Tool");
+        let _guard = span.enter();
+
         Command::new("C:\\Program Files (x86)\\ASRock Utility\\ASRPGT\\Bin\\AsrPGT.exe")
             .spawn()
             .expect("Unable to launch ASRock Tweak Tool");
@@ -179,12 +199,13 @@ impl Gpu {
     }
 
     pub fn reset_fan_throttle(&mut self) {
+        let span = info_span!("Resetting fan throttle");
+        let _guard = span.enter();
+
         self.kill_asrock_tweak_tool();
-        info!("Changing to fixed fan throttle");
         self.set_fan_throttle(FanThrottle::Fixed);
         self.launch_asrock_tweak_tool();
         self.kill_asrock_tweak_tool();
-        info!("Changing back to smart fan throttle");
         self.set_fan_throttle(FanThrottle::Smart);
         self.launch_asrock_tweak_tool();
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,24 +5,27 @@ extern crate ati_adl_sys;
 extern crate cpal;
 extern crate crossbeam_channel;
 extern crate ctrlc;
-extern crate env_logger;
 #[macro_use]
 extern crate int_enum;
-#[macro_use]
-extern crate log;
 extern crate sysinfo;
+extern crate tracing;
+extern crate tracing_appender;
+extern crate tracing_subscriber;
 
 mod gpu;
 mod sound;
 
 use crossbeam_channel::{bounded, select, tick, Receiver};
-use env_logger::Env;
 use gpu::Gpu;
 use std::time::Duration;
+use tracing::{info, Level};
+use tracing_subscriber::FmtSubscriber;
 
 fn main() -> anyhow::Result<()> {
-    let env = Env::default().filter_or("MY_LOG_LEVEL", "info");
-    env_logger::init_from_env(env);
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(Level::INFO)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
     let mut gpu = Gpu::get_active_gpu();
 


### PR DESCRIPTION
Replace the use of the `log` facade and the `env_logger` logging framework with the `tracing` library, which emulates the `log` crate.  Now logs both to console err and to a log file.  Also takes advantage of tagged data in `tracing` to give structured output in logs.